### PR TITLE
Support alternate pci.ids path at /usr/share/hwdata/pci.ids

### DIFF
--- a/lib/facter/nic_info.rb
+++ b/lib/facter/nic_info.rb
@@ -37,9 +37,9 @@ Facter.add(:nic_info) do
   end
 
   def model_from_ids(vendor_id, device_id)
-    pci_id_database_path = '/usr/share/misc/pci.ids'
-    return '', '' unless File.file?(pci_id_database_path)
-    pci_id_database_content = File.read(pci_id_database_path)
+    pci_id_database_path = ['/usr/share/misc/pci.ids', '/usr/share/hwdata/pci.ids'].find { |path| File.file?(path) }
+    return '', '' unless pci_id_database_path
+    pci_id_database_content = File.read(pci_id_database_path, encoding: 'UTF-8')
     pci_id_database = parse_pci_id_database(pci_id_database_content)
     vendor_id_without_hex_prefix = vendor_id.gsub('0x', '').downcase
     device_id_without_hex_prefix = device_id.gsub('0x', '').downcase
@@ -60,7 +60,7 @@ Facter.add(:nic_info) do
       end
 
       vendor_id = File.read(vendor_id_path).strip
-      device_id =  File.read(device_id_path).strip
+      device_id = File.read(device_id_path).strip
       vendor_name, device_name = model_from_ids(vendor_id, device_id)
 
       result[interface] = {

--- a/spec/unit/facter/nic_info_spec.rb
+++ b/spec/unit/facter/nic_info_spec.rb
@@ -7,6 +7,18 @@ require 'facter/nic_info'
 describe :nic_info, type: :fact do
   subject(:fact) { Facter.fact(:nic_info) }
 
+  let(:pci_ids_content) { File.read(File.join(__dir__, 'pci.ids')) }
+  let(:expected_result) do
+    {
+      'eno1' => {
+        'vendor_id' => '0x8086',
+        'device_id' => '0x1563',
+        'vendor_name' => 'Intel Corporation',
+        'device_name' => 'Ethernet Controller X550',
+      }
+    }
+  end
+
   before :each do
     Facter.clear
     allow(Facter.fact(:networking)).to receive(:value).and_return(
@@ -19,21 +31,49 @@ describe :nic_info, type: :fact do
     allow(File).to receive(:file?).and_call_original
     allow(File).to receive(:file?).with('/sys/class/net/eno1/device/vendor').and_return(true)
     allow(File).to receive(:file?).with('/sys/class/net/eno1/device/device').and_return(true)
-    allow(File).to receive(:file?).with('/usr/share/misc/pci.ids').and_return(true)
     allow(File).to receive(:read).and_call_original
     allow(File).to receive(:read).with('/sys/class/net/eno1/device/vendor').and_return('0x8086')
     allow(File).to receive(:read).with('/sys/class/net/eno1/device/device').and_return('0x1563')
-    allow(File).to receive(:read).with('/usr/share/misc/pci.ids').and_return(File.read(File.join(__dir__, 'pci.ids')))
   end
 
-  it 'returns a value' do
-    expect(fact.value).to eq({
-                               'eno1' => {
-                                 'vendor_id' => '0x8086',
-                                 'device_id' => '0x1563',
-                                 'vendor_name' => 'Intel Corporation',
-                                 'device_name' => 'Ethernet Controller X550',
-                               }
-                             })
+  context 'when pci.ids is at /usr/share/misc/pci.ids' do
+    before :each do
+      allow(File).to receive(:file?).with('/usr/share/misc/pci.ids').and_return(true)
+      allow(File).to receive(:read).with('/usr/share/misc/pci.ids', encoding: 'UTF-8').and_return(pci_ids_content)
+    end
+
+    it 'returns a value' do
+      expect(fact.value).to eq(expected_result)
+    end
+  end
+
+  context 'when pci.ids is at /usr/share/hwdata/pci.ids' do
+    before :each do
+      allow(File).to receive(:file?).with('/usr/share/misc/pci.ids').and_return(false)
+      allow(File).to receive(:file?).with('/usr/share/hwdata/pci.ids').and_return(true)
+      allow(File).to receive(:read).with('/usr/share/hwdata/pci.ids', encoding: 'UTF-8').and_return(pci_ids_content)
+    end
+
+    it 'returns a value' do
+      expect(fact.value).to eq(expected_result)
+    end
+  end
+
+  context 'when pci.ids is not found' do
+    before :each do
+      allow(File).to receive(:file?).with('/usr/share/misc/pci.ids').and_return(false)
+      allow(File).to receive(:file?).with('/usr/share/hwdata/pci.ids').and_return(false)
+    end
+
+    it 'returns empty vendor and device names' do
+      expect(fact.value).to eq({
+                                 'eno1' => {
+                                   'vendor_id' => '0x8086',
+                                   'device_id' => '0x1563',
+                                   'vendor_name' => '',
+                                   'device_name' => '',
+                                 }
+                               })
+    end
   end
 end


### PR DESCRIPTION
Supersedes #2.

On RHEL, CentOS, and Fedora the PCI ID database is located at `/usr/share/hwdata/pci.ids` rather than `/usr/share/misc/pci.ids`. This change tries both paths before falling back to empty vendor/device names. The file is now read with explicit UTF-8 encoding to prevent invalid byte sequence errors on systems where the locale does not default to UTF-8.

Unlike #2, this PR does not introduce Facter 2 / Ruby 2.0.0 compatibility code since the module already requires Puppet >= 7.24 (which ships Ruby >= 2.7). Keeping `casecmp`, `match?`, and `Hash#dig` as they are is the correct choice for the supported Ruby versions.

Tests have been expanded to cover the primary path, the alternate path, and the missing-database fallback.

Credit to @genebean for identifying the issue.