### PR TITLE
Fix rubocop compatibility for newer versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,8 @@ require:
 - rubocop-rspec
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.6'
+  NewCops: disable
+  TargetRubyVersion: '2.7'
   Include:
   - "**/*.rb"
   Exclude:
@@ -116,6 +117,8 @@ Bundler/GemFilename:
 Bundler/InsecureProtocolSource:
   Enabled: false
 Capybara/CurrentPathExpectation:
+  Enabled: false
+Capybara/RSpec/PredicateMatcher:
   Enabled: false
 Capybara/VisibilityMatcher:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :development do
   gem "pry", '~> 0.10',                          require: false
   gem "simplecov-console", '~> 0.5',             require: false
   gem "puppet-debugger", '~> 1.0',               require: false
-  gem "rubocop", '= 1.48.1',                     require: false
+  gem "rubocop", '~> 1.48',                       require: false
   gem "rubocop-performance", '= 1.16.0',         require: false
   gem "rubocop-rspec", '= 2.19.0',               require: false
   gem "puppet-strings", '~> 4.0',                require: false

--- a/lib/facter/nic_info.rb
+++ b/lib/facter/nic_info.rb
@@ -51,7 +51,7 @@ Facter.add(:nic_info) do
 
   setcode do
     result = {}
-    Facter.value(:networking)['interfaces'].each do |interface, _|
+    Facter.value(:networking)['interfaces'].each_key do |interface|
       sys_path_prefix = "/sys/class/net/#{interface}"
       vendor_id_path = "#{sys_path_prefix}/device/vendor"
       device_id_path = "#{sys_path_prefix}/device/device"


### PR DESCRIPTION
The rubocop version was pinned to 1.48.1 which prevented Dependabot from upgrading it. This PR relaxes the version constraint to `~> 1.48`, updates `TargetRubyVersion` from 2.6 to 2.7 (rubocop 1.68+ dropped 2.6 support), adds `NewCops: disable` to prevent future upgrade breakage, fixes the `Style/HashEachMethods` offense in `nic_info.rb`, and disables the crashing `Capybara/RSpec/PredicateMatcher` cop.