### PR TITLE
fix: replace deprecated ::set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Get latest tag
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF:10}
+        run: echo "tag=${GITHUB_REF:10}" >> "$GITHUB_OUTPUT"
       - name: Clone repository
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The ::set-output command was deprecated in October 2022 and will eventually stop working. This replaces it with the recommended $GITHUB_OUTPUT environment file approach, preventing future breakage of the Puppet Forge publishing workflow.