### PR TITLE
fix: correct typos and path placeholders in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Augment your facts with vendor and device info for each interface.
 
 ## Description
 
-Puppet's default facts to not expose the model or vendor of a physical NIC.
-This module fetches the vendor ID from `/sys/class/net/<interface>>/device/vendor` and the device ID from `/sys/class/net/eno1/device/device`.
+Puppet's default facts do not expose the model or vendor of a physical NIC.
+This module fetches the vendor ID from `/sys/class/net/<interface>/device/vendor` and the device ID from `/sys/class/net/<interface>/device/device`.
 Additionally it tries to resolve the vendor name and device (model) name from `/usr/share/misc/pci.ids`.
 This approach is really fast compared to tools like `lshw` and does not require any additional binary.
 


### PR DESCRIPTION
Fix typo "to not expose" -> "do not expose", remove extra closing angle bracket in sysfs vendor path, and replace hardcoded eno1 with <interface> placeholder in the device path for consistency.