### PR TITLE
Bump barnumbirr/action-forge-publish from 2.9.2 to 2.15.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: ${{ steps.vars.outputs.tag }}
       - name: Build and publish module
-        uses: barnumbirr/action-forge-publish@v2.9.2
+        uses: barnumbirr/action-forge-publish@v2.15.0
         env:
           FORGE_API_KEY: ${{ secrets.FORGE_API_KEY }}
           REPOSITORY_URL: https://forgeapi.puppet.com/v3/releases


### PR DESCRIPTION
Supersedes #6. Bumps barnumbirr/action-forge-publish from 2.9.2 to 2.15.0, applied on top of the already-updated main branch which includes the fixed \`\$GITHUB_OUTPUT\` syntax and \`actions/checkout@v6\`.